### PR TITLE
Add OpenAI integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,18 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<version>42.7.3</version>
-		</dependency>
+                <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <version>42.7.3</version>
+                </dependency>
+
+                <!-- OpenAI Java client -->
+                <dependency>
+                        <groupId>com.theokanning.openai-gpt3-java</groupId>
+                        <artifactId>service</artifactId>
+                        <version>0.18.2</version>
+                </dependency>
 
 		<!-- Swagger / OpenAPI -->
 		<dependency>

--- a/src/main/java/com/portfolio/config/OpenAIConfig.java
+++ b/src/main/java/com/portfolio/config/OpenAIConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OpenAIConfig {
 
-    @Value("${openai.api.key}")
+    @Value("${openai.api.key:}")
     private String apiKey;
 
     @Bean

--- a/src/main/java/com/portfolio/config/OpenAIConfig.java
+++ b/src/main/java/com/portfolio/config/OpenAIConfig.java
@@ -1,0 +1,18 @@
+package com.portfolio.config;
+
+import com.theokanning.openai.service.OpenAiService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAIConfig {
+
+    @Value("${openai.api.key}")
+    private String apiKey;
+
+    @Bean
+    public OpenAiService openAiService() {
+        return new OpenAiService(apiKey);
+    }
+}

--- a/src/main/java/com/portfolio/controller/AIController.java
+++ b/src/main/java/com/portfolio/controller/AIController.java
@@ -1,10 +1,11 @@
 package com.portfolio.controller;
 
+import com.portfolio.dto.StackRequest;
 import com.portfolio.service.AIService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Map;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/ai")
@@ -18,8 +19,9 @@ public class AIController {
     }
 
     @PostMapping("/message")
-    public ResponseEntity<String> getMessage(@RequestBody Map<String, String> body) {
-        String stack = body.get("stack");
+    public ResponseEntity<String> getMessage(@RequestBody StackRequest body) {
+        List<String> stackList = body.getStack();
+        String stack = String.join(", ", stackList);
         String msg = aiService.generateDynamicMessage(stack);
         return ResponseEntity.ok(msg);
     }

--- a/src/main/java/com/portfolio/dto/StackRequest.java
+++ b/src/main/java/com/portfolio/dto/StackRequest.java
@@ -1,0 +1,10 @@
+package com.portfolio.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class StackRequest {
+    private List<String> stack;
+}

--- a/src/main/java/com/portfolio/service/AIService.java
+++ b/src/main/java/com/portfolio/service/AIService.java
@@ -1,12 +1,30 @@
 package com.portfolio.service;
 
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
+import com.theokanning.openai.completion.chat.ChatCompletionResult;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import com.theokanning.openai.service.OpenAiService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
+@RequiredArgsConstructor
 public class AIService {
 
+    private final OpenAiService openAiService;
+
     public String generateDynamicMessage(String stack) {
-        // Lógica fake para MVP
-        return "This project uses: " + stack;
+        ChatMessage userMessage = new ChatMessage("user", "Describe a project using: " + stack);
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model("gpt-3.5-turbo")
+                .messages(List.of(userMessage))
+                .maxTokens(60)
+                .build();
+
+        ChatCompletionResult result = openAiService.createChatCompletion(request);
+        return result.getChoices().getFirst().getMessage().getContent().trim();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,4 +36,4 @@ logging.level.org.hibernate=DEBUG
 logging.level.com.portfolio=DEBUG
 
 # API key para OpenAI
-openai.api.key=${OPENAI_API_KEY}
+openai.api.key=${OPENAI_API_KEY:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,3 +34,6 @@ spring.datasource.hikari.data-source-properties.prepStmtCacheSqlLimit=0
 logging.level.org.springframework.web=DEBUG
 logging.level.org.hibernate=DEBUG
 logging.level.com.portfolio=DEBUG
+
+# API key para OpenAI
+openai.api.key=${OPENAI_API_KEY}

--- a/src/test/java/com/portfolio/controller/AIControllerTest.java
+++ b/src/test/java/com/portfolio/controller/AIControllerTest.java
@@ -1,0 +1,46 @@
+package com.portfolio.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.portfolio.dto.StackRequest;
+import com.portfolio.service.AIService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AIController.class)
+class AIControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AIService aiService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void testGetMessage() throws Exception {
+        StackRequest req = new StackRequest();
+        req.setStack(List.of("Angular", "Spring Boot"));
+
+        Mockito.when(aiService.generateDynamicMessage("Angular, Spring Boot"))
+                .thenReturn("Answer");
+
+        mockMvc.perform(post("/api/ai/message")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Answer"));
+    }
+}

--- a/src/test/java/com/portfolio/service/AIServiceTest.java
+++ b/src/test/java/com/portfolio/service/AIServiceTest.java
@@ -1,13 +1,41 @@
 package com.portfolio.service;
 
+import com.theokanning.openai.completion.chat.ChatCompletionChoice;
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
+import com.theokanning.openai.completion.chat.ChatCompletionResult;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import com.theokanning.openai.service.OpenAiService;
 import org.junit.jupiter.api.Test;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
 class AIServiceTest {
+
+    @Mock
+    private OpenAiService openAiService;
+
     @Test
     void generatesMessage() {
-        AIService service = new AIService();
-        assertThat(service.generateDynamicMessage("Angular, Spring Boot"))
-                .isEqualTo("This project uses: Angular, Spring Boot");
+        ChatMessage msg = new ChatMessage();
+        msg.setContent("Hello!");
+        ChatCompletionChoice choice = new ChatCompletionChoice();
+        choice.setMessage(msg);
+        ChatCompletionResult result = new ChatCompletionResult();
+        result.setChoices(List.of(choice));
+
+        when(openAiService.createChatCompletion(any(ChatCompletionRequest.class))).thenReturn(result);
+
+        AIService service = new AIService(openAiService);
+        String response = service.generateDynamicMessage("Java");
+
+        assertThat(response).isEqualTo("Hello!");
     }
 }


### PR DESCRIPTION
## Summary
- integrate official OpenAI Java client
- configure `openai.api.key` property
- create OpenAI configuration bean
- connect AIService to OpenAI
- mock OpenAI client in AIService tests

## Testing
- `./mvnw -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685a28b8e9b083339c60b49be6378a85