### PR TITLE
Add endpoint for AI message generation per project

### DIFF
--- a/src/main/java/com/portfolio/config/OpenAIConfig.java
+++ b/src/main/java/com/portfolio/config/OpenAIConfig.java
@@ -10,9 +10,9 @@ public class OpenAIConfig {
 
     @Bean
     public OpenAiService openAiService() {
-        String key = System.getenv("OPENAI_API_KEY"); // PRIMERO VARIABLES DE ENTORNO
+        String key = System.getenv("OPENAI_API_KEY");
         if (key == null || key.isEmpty()) {
-            Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load(); // SOLO SI NO ENCUENTRA VARIABLE DE ENTORNO
+            Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
             key = dotenv.get("OPENAI_API_KEY");
         }
         if (key == null || key.isEmpty()) {

--- a/src/main/java/com/portfolio/controller/ProjectController.java
+++ b/src/main/java/com/portfolio/controller/ProjectController.java
@@ -43,4 +43,10 @@ public class ProjectController {
     public ResponseEntity<ProjectDTO> updateProject(@PathVariable Long id, @Valid @RequestBody ProjectDTO dto) {
         return ResponseEntity.ok(projectService.updateProject(id, dto));
     }
+
+    @GetMapping("/{id}/ai-message")
+    @Operation(summary = "Generar mensaje dinámico para un proyecto")
+    public ResponseEntity<String> getDynamicMessage(@PathVariable Long id) {
+        return ResponseEntity.ok(projectService.generateDynamicMessage(id));
+    }
 }

--- a/src/main/java/com/portfolio/service/AIService.java
+++ b/src/main/java/com/portfolio/service/AIService.java
@@ -16,7 +16,8 @@ public class AIService {
     private final OpenAiService openAiService;
 
     public String generateDynamicMessage(String stack) {
-        ChatMessage userMessage = new ChatMessage("user", "Describe a project using: " + stack);
+        String prompt = buildOptimizedPrompt(stack);
+        ChatMessage userMessage = new ChatMessage("user", prompt);
 
         ChatCompletionRequest request = ChatCompletionRequest.builder()
                 .model("gpt-3.5-turbo")
@@ -26,5 +27,20 @@ public class AIService {
 
         ChatCompletionResult result = openAiService.createChatCompletion(request);
         return result.getChoices().getFirst().getMessage().getContent().trim();
+    }
+
+    String buildOptimizedPrompt(String stack) {
+        String[] parts = stack.split(",");
+        String primaryStack = parts.length > 0 ? parts[0].trim() : stack;
+        return "Generate a personalized professional message for a software developer's portfolio. " +
+                "Context: User is viewing a project which uses " + stack + ".\n" +
+                "Primary technology: " + primaryStack + "\n" +
+                "Requirements:\n" +
+                "- Professional tone, 2-3 sentences max\n" +
+                "- Highlight expertise in " + primaryStack + "\n" +
+                "- Include relevant technical keywords\n" +
+                "- Available in English and Spanish\n" +
+                "- JSON format: {\"en\": \"message\", \"es\": \"mensaje\"}\n" +
+                "Focus on demonstrating deep knowledge and practical experience with the technology stack.";
     }
 }

--- a/src/main/java/com/portfolio/service/AIService.java
+++ b/src/main/java/com/portfolio/service/AIService.java
@@ -22,7 +22,7 @@ public class AIService {
         ChatCompletionRequest request = ChatCompletionRequest.builder()
                 .model("gpt-3.5-turbo")
                 .messages(List.of(userMessage))
-                .maxTokens(60)
+                .maxTokens(600)
                 .build();
 
         ChatCompletionResult result = openAiService.createChatCompletion(request);

--- a/src/main/java/com/portfolio/service/ProjectService.java
+++ b/src/main/java/com/portfolio/service/ProjectService.java
@@ -6,7 +6,6 @@ import com.portfolio.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -16,6 +15,7 @@ import java.util.stream.Collectors;
 public class ProjectService {
 
     private final ProjectRepository projectRepository;
+    private final AIService aiService;
     private final DateTimeFormatter dateFormatter = DateTimeFormatter.ISO_DATE;
 
     public List<ProjectDTO> getAllProjects() {
@@ -44,6 +44,18 @@ public class ProjectService {
         project.setCreatedDate(dto.getCreatedDate());
         project = projectRepository.save(project);
         return toDto(project);
+    }
+
+    public ProjectDTO getProject(Long id) {
+        Project project = projectRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Project not found with id: " + id));
+        return toDto(project);
+    }
+
+    public String generateDynamicMessage(Long id) {
+        Project project = projectRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Project not found with id: " + id));
+        return aiService.generateDynamicMessage(project.getStack());
     }
 
     private Project toEntity(ProjectDTO dto) {

--- a/src/test/java/com/portfolio/controller/ProjectControllerTest.java
+++ b/src/test/java/com/portfolio/controller/ProjectControllerTest.java
@@ -97,4 +97,13 @@ class ProjectControllerTest {
         mockMvc.perform(delete("/api/projects/1"))
                 .andExpect(status().is(204));
     }
+
+    @Test
+    void testGetDynamicMessage() throws Exception {
+        Mockito.when(projectService.generateDynamicMessage(1L)).thenReturn("Hi");
+
+        mockMvc.perform(get("/api/projects/1/ai-message"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Hi"));
+    }
 }

--- a/src/test/java/com/portfolio/service/AIServiceTest.java
+++ b/src/test/java/com/portfolio/service/AIServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 
@@ -31,11 +32,16 @@ class AIServiceTest {
         ChatCompletionResult result = new ChatCompletionResult();
         result.setChoices(List.of(choice));
 
-        when(openAiService.createChatCompletion(any(ChatCompletionRequest.class))).thenReturn(result);
+        ArgumentCaptor<ChatCompletionRequest> captor = ArgumentCaptor.forClass(ChatCompletionRequest.class);
+        when(openAiService.createChatCompletion(captor.capture())).thenReturn(result);
 
         AIService service = new AIService(openAiService);
-        String response = service.generateDynamicMessage("Java");
+        String response = service.generateDynamicMessage("Java, Spring");
 
         assertThat(response).isEqualTo("Hello!");
+        ChatCompletionRequest sent = captor.getValue();
+        assertThat(sent.getMessages().get(0).getContent())
+                .contains("uses Java, Spring")
+                .contains("Primary technology: Java");
     }
 }

--- a/src/test/java/com/portfolio/service/ProjectServiceTest.java
+++ b/src/test/java/com/portfolio/service/ProjectServiceTest.java
@@ -1,0 +1,34 @@
+package com.portfolio.service;
+
+import com.portfolio.model.Project;
+import com.portfolio.repository.ProjectRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceTest {
+
+    @Mock
+    private ProjectRepository projectRepository;
+    @Mock
+    private AIService aiService;
+
+    @Test
+    void generateMessageUsesProjectStack() {
+        Project project = Project.builder().id(1L).stack("Java").build();
+        when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+        when(aiService.generateDynamicMessage("Java")).thenReturn("Hi");
+
+        ProjectService service = new ProjectService(projectRepository, aiService);
+        String msg = service.generateDynamicMessage(1L);
+
+        assertThat(msg).isEqualTo("Hi");
+    }
+}


### PR DESCRIPTION
## Summary
- add AIService dependency to `ProjectService`
- add `generateDynamicMessage` method and `getProject`
- expose `/api/projects/{id}/ai-message` endpoint
- create `ProjectServiceTest`
- test new controller endpoint
- add optimized prompt builder in `AIService`

## Testing
- `./mvnw -q test` *(fails: unable to fetch Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685c942649f48333b97d42a1b68e2529