### PR TITLE
Add contextual chat service

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ Las respuestas devuelven un JSON con la forma:
 { "message": "texto" }
 ```
 
+### 💬 **Chat**
+
+| Método | Endpoint | Descripción |
+| ------ | -------- | ----------- |
+| `POST` | `/api/chat/context` | Registrar contexto de navegación |
+| `GET`  | `/api/chat/agent/{type}` | Obtener información de un agente |
+| `POST` | `/api/chat/message` | Enviar mensaje contextual al asistente |
+
 ---
 
 ## ⚙ **Arquitectura y flujo lógico**

--- a/src/main/java/com/portfolio/controller/ChatController.java
+++ b/src/main/java/com/portfolio/controller/ChatController.java
@@ -1,0 +1,33 @@
+package com.portfolio.controller;
+
+import com.portfolio.dto.*;
+import com.portfolio.service.AIService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/chat")
+@CrossOrigin(origins = "*")
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final AIService aiService;
+
+    @PostMapping("/context")
+    public ResponseEntity<?> updateContext(@RequestBody ContextRequest request) {
+        aiService.recordContext("default", request);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/agent/{type}")
+    public ResponseEntity<AgentInfo> getAgent(@PathVariable AgentType type) {
+        return ResponseEntity.ok(aiService.getAgentInfo(type));
+    }
+
+    @PostMapping("/message")
+    public ResponseEntity<MessageResponse> sendMessage(@RequestBody ChatMessageRequest req) {
+        String reply = aiService.generateContextAwareResponse(req.getMessage(), "default", req.getContext(), req.getAgent());
+        return ResponseEntity.ok(new MessageResponse(reply));
+    }
+}

--- a/src/main/java/com/portfolio/dto/AgentInfo.java
+++ b/src/main/java/com/portfolio/dto/AgentInfo.java
@@ -1,0 +1,15 @@
+package com.portfolio.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AgentInfo {
+    private AgentType type;
+    private String name;
+    private String icon;
+    private String description;
+}

--- a/src/main/java/com/portfolio/dto/AgentType.java
+++ b/src/main/java/com/portfolio/dto/AgentType.java
@@ -1,0 +1,8 @@
+package com.portfolio.dto;
+
+public enum AgentType {
+    PROJECT_GUIDE,
+    TECH_EXPERT,
+    PORTFOLIO_HOST,
+    CONTACT_ASSISTANT
+}

--- a/src/main/java/com/portfolio/dto/ChatMessageRequest.java
+++ b/src/main/java/com/portfolio/dto/ChatMessageRequest.java
@@ -1,0 +1,10 @@
+package com.portfolio.dto;
+
+import lombok.Data;
+
+@Data
+public class ChatMessageRequest {
+    private String message;
+    private ContextInfo context;
+    private AgentType agent;
+}

--- a/src/main/java/com/portfolio/dto/ContextInfo.java
+++ b/src/main/java/com/portfolio/dto/ContextInfo.java
@@ -1,0 +1,11 @@
+package com.portfolio.dto;
+
+import lombok.Data;
+
+@Data
+public class ContextInfo {
+    private String section;
+    private String projectId;
+    private Object metadata;
+    private String timestamp;
+}

--- a/src/main/java/com/portfolio/dto/ContextRequest.java
+++ b/src/main/java/com/portfolio/dto/ContextRequest.java
@@ -1,0 +1,11 @@
+package com.portfolio.dto;
+
+import lombok.Data;
+
+@Data
+public class ContextRequest {
+    private String section;
+    private String projectId;
+    private String action;
+    private Object userContext;
+}

--- a/src/main/java/com/portfolio/service/AIService.java
+++ b/src/main/java/com/portfolio/service/AIService.java
@@ -4,16 +4,26 @@ import com.theokanning.openai.completion.chat.ChatCompletionRequest;
 import com.theokanning.openai.completion.chat.ChatCompletionResult;
 import com.theokanning.openai.completion.chat.ChatMessage;
 import com.theokanning.openai.service.OpenAiService;
+import com.portfolio.dto.*;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AIService {
 
     private final OpenAiService openAiService;
+
+    private final Map<String, UserSession> userSessions = new ConcurrentHashMap<>();
 
     public String generateDynamicMessage(String stack) {
         String prompt = buildOptimizedPrompt(stack);
@@ -64,5 +74,132 @@ public class AIService {
                 "- Available in English and Spanish\n" +
                 "- JSON format: {\"en\": \"message\", \"es\": \"mensaje\"}\n" +
                 "Focus on demonstrating deep knowledge and practical experience with the technology stack.";
+    }
+
+    /* === New contextual intelligence === */
+
+    public void recordContext(String sessionId, ContextRequest req) {
+        UserSession session = getOrCreateSession(sessionId);
+        ContextInfo info = new ContextInfo();
+        info.setSection(req.getSection());
+        info.setProjectId(req.getProjectId());
+        info.setMetadata(req.getUserContext());
+        info.setTimestamp(Instant.now().toString());
+        session.getVisitedSections().add(info);
+    }
+
+    public AgentInfo getAgentInfo(AgentType type) {
+        return switch (type) {
+            case PROJECT_GUIDE -> new AgentInfo(type, "Project Guide", "\uD83D\uDCC2", "Entusiasta técnico, explica arquitecturas");
+            case TECH_EXPERT -> new AgentInfo(type, "Tech Expert", "\uD83D\uDCBB", "Formal y con jerga avanzada");
+            case PORTFOLIO_HOST -> new AgentInfo(type, "Portfolio Host", "\uD83C\uDF99", "Amigable y comercial");
+            case CONTACT_ASSISTANT -> new AgentInfo(type, "Contact Assistant", "\u2709", "Profesional y directo");
+        };
+    }
+
+    public String generateContextAwareResponse(String message, String sessionId, ContextInfo context, AgentType agent) {
+        UserSession session = getOrCreateSession(sessionId);
+        session.setCurrentAgent(agent);
+        session.getConversationHistory().add(message);
+        String prompt = buildIntelligentPrompt(message, context, session);
+        int tokens = calculateOptimalTokens(session, context);
+        return sendPrompt(prompt + "\nMensaje actual: " + message, tokens);
+    }
+
+    public String generateRobustResponse(String message, ContextInfo context, String sessionId) {
+        try {
+            return generateContextAwareResponse(message, sessionId, context, AgentType.PORTFOLIO_HOST);
+        } catch (Exception e) {
+            log.warn("AI service error, using fallback", e);
+            return generateFallbackResponse(message, context);
+        }
+    }
+
+    private String generateFallbackResponse(String message, ContextInfo context) {
+        return "Lo siento, no puedo responder en este momento.";
+    }
+
+    private String buildIntelligentPrompt(String userInput, ContextInfo context, UserSession session) {
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("Act\u00FAa como ").append(getAgentPersonality(session.getCurrentAgent()));
+        if (!session.getVisitedSections().isEmpty()) {
+            prompt.append(" El usuario ha visitado: ");
+            session.getVisitedSections().stream()
+                    .map(ContextInfo::getSection)
+                    .distinct()
+                    .forEach(s -> prompt.append(s).append(" "));
+        }
+        if (context != null && context.getProjectId() != null) {
+            prompt.append(" Contexto actual: proyecto ").append(context.getProjectId());
+        }
+        double engagement = calculateUserEngagement(session, context != null ? context.getSection() : null);
+        if (engagement > 0.7) {
+            prompt.append(" Usuario altamente interesado, profundizar en detalles t\u00E9cnicos.");
+        } else if (engagement < 0.3) {
+            prompt.append(" Usuario explorando superficialmente, mantener respuestas concisas y atractivas.");
+        }
+        return prompt.toString();
+    }
+
+    private double calculateUserEngagement(UserSession session, String currentSection) {
+        return 0.5; // placeholder heuristic
+    }
+
+    private int calculateOptimalTokens(UserSession session, ContextInfo context) {
+        int base = 200;
+        if (context != null && "projects".equals(context.getSection())) base += 100;
+        double engagement = calculateUserEngagement(session, context != null ? context.getSection() : null);
+        if (engagement > 0.8) base += 150;
+        if (session.getConversationHistory().size() > 5) base -= 50;
+        return Math.max(150, Math.min(600, base));
+    }
+
+    private String getAgentPersonality(AgentType agent) {
+        return switch (agent) {
+            case PROJECT_GUIDE -> "Entusiasta t\u00E9cnico";
+            case TECH_EXPERT -> "Especialista formal";
+            case PORTFOLIO_HOST -> "Anfitri\u00F3n amigable";
+            case CONTACT_ASSISTANT -> "Asistente profesional";
+        };
+    }
+
+    private UserSession getOrCreateSession(String sessionId) {
+        return userSessions.computeIfAbsent(sessionId, id -> {
+            UserSession s = new UserSession();
+            s.setVisitedSections(new ArrayList<>());
+            s.setProjectInterestScores(new ConcurrentHashMap<>());
+            s.setConversationHistory(new ArrayList<>());
+            s.setSessionStartTime(System.currentTimeMillis());
+            s.setCurrentAgent(AgentType.PORTFOLIO_HOST);
+            return s;
+        });
+    }
+
+    @Scheduled(fixedRate = 300000)
+    public void analyzeUserPatterns() {
+        userSessions.values().forEach(this::updateUserBehaviorModel);
+    }
+
+    private void updateUserBehaviorModel(UserSession session) {
+        // placeholder for learning algorithm
+    }
+
+    public static class UserSession {
+        private List<ContextInfo> visitedSections;
+        private Map<String, Integer> projectInterestScores;
+        private List<String> conversationHistory;
+        private AgentType currentAgent;
+        private long sessionStartTime;
+
+        public List<ContextInfo> getVisitedSections() { return visitedSections; }
+        public void setVisitedSections(List<ContextInfo> visitedSections) { this.visitedSections = visitedSections; }
+        public Map<String, Integer> getProjectInterestScores() { return projectInterestScores; }
+        public void setProjectInterestScores(Map<String, Integer> projectInterestScores) { this.projectInterestScores = projectInterestScores; }
+        public List<String> getConversationHistory() { return conversationHistory; }
+        public void setConversationHistory(List<String> conversationHistory) { this.conversationHistory = conversationHistory; }
+        public AgentType getCurrentAgent() { return currentAgent; }
+        public void setCurrentAgent(AgentType currentAgent) { this.currentAgent = currentAgent; }
+        public long getSessionStartTime() { return sessionStartTime; }
+        public void setSessionStartTime(long sessionStartTime) { this.sessionStartTime = sessionStartTime; }
     }
 }

--- a/src/test/java/com/portfolio/controller/ChatControllerTest.java
+++ b/src/test/java/com/portfolio/controller/ChatControllerTest.java
@@ -1,0 +1,75 @@
+package com.portfolio.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.portfolio.dto.*;
+import com.portfolio.service.AIService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ChatController.class)
+class ChatControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AIService aiService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void testUpdateContext() throws Exception {
+        ContextRequest req = new ContextRequest();
+        req.setSection("projects");
+        req.setProjectId("1");
+        req.setAction("open");
+        req.setUserContext(Map.of());
+
+        Mockito.doNothing().when(aiService).recordContext(Mockito.eq("default"), Mockito.any());
+
+        mockMvc.perform(post("/api/chat/context")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testGetAgent() throws Exception {
+        AgentInfo info = new AgentInfo(AgentType.PROJECT_GUIDE, "Project Guide", "i", "d");
+        Mockito.when(aiService.getAgentInfo(AgentType.PROJECT_GUIDE)).thenReturn(info);
+
+        mockMvc.perform(get("/api/chat/agent/PROJECT_GUIDE"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Project Guide"));
+    }
+
+    @Test
+    void testSendMessage() throws Exception {
+        ChatMessageRequest req = new ChatMessageRequest();
+        ContextInfo ctx = new ContextInfo();
+        ctx.setSection("projects");
+        req.setMessage("Hi");
+        req.setContext(ctx);
+        req.setAgent(AgentType.PROJECT_GUIDE);
+
+        Mockito.when(aiService.generateContextAwareResponse("Hi", "default", ctx, AgentType.PROJECT_GUIDE))
+                .thenReturn("Answer");
+
+        mockMvc.perform(post("/api/chat/message")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Answer"));
+    }
+}


### PR DESCRIPTION
## Summary
- expand `AIService` with robust fallback support
- implement Chat controller tests for context, agent info and messages

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_b_685f826dd2208333b22570d724313846