### PR TITLE
Read allowed origins from config

### DIFF
--- a/src/main/java/com/portfolio/config/CorsConfig.java
+++ b/src/main/java/com/portfolio/config/CorsConfig.java
@@ -2,18 +2,23 @@ package com.portfolio.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class CorsConfig {
+
+    @Value("${app.cors.allowed-origins}")
+    private String corsAllowedOrigins;
     @Bean
     public WebMvcConfigurer corsConfigurer() {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
+                String[] origins = corsAllowedOrigins.split("\\s*,\\s*");
                 registry.addMapping("/**")
-                        .allowedOrigins("http://localhost:4200", "https://portfolio-frontend-e0bee.web.app", "https://bernarduriza.com")
+                        .allowedOrigins(origins)
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("*");
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -44,3 +44,4 @@ spring.mail.properties.mail.smtp.starttls.enable=true
 
 app.mail.from=contact@bernarduriza.com
 app.mail.to=bernarduriza@gmail.com
+app.cors.allowed-origins=http://localhost:4200,https://portfolio-frontend-e0bee.web.app,https://bernarduriza.com


### PR DESCRIPTION
## Summary
- add new property `app.cors.allowed-origins`
- read comma-separated list in `CorsConfig`

## Testing
- `./mvnw -q test` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_b_6861f8eddbbc833386bc2a59fbc38c63