### PR TITLE
Add centralized exception handler

### DIFF
--- a/src/main/java/com/portfolio/dto/ErrorResponse.java
+++ b/src/main/java/com/portfolio/dto/ErrorResponse.java
@@ -1,0 +1,10 @@
+package com.portfolio.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ErrorResponse {
+    private String error;
+}

--- a/src/main/java/com/portfolio/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/portfolio/exception/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.portfolio.exception;
+
+import com.portfolio.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFound(ResourceNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex) {
+        String msg = ex.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining(", "));
+        return ResponseEntity.badRequest().body(new ErrorResponse(msg));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntime(RuntimeException ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse(ex.getMessage()));
+    }
+}

--- a/src/main/java/com/portfolio/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/portfolio/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.portfolio.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/portfolio/service/ContactService.java
+++ b/src/main/java/com/portfolio/service/ContactService.java
@@ -3,6 +3,7 @@ package com.portfolio.service;
 import com.portfolio.dto.ContactDTO;
 import com.portfolio.model.Contact;
 import com.portfolio.repository.ContactRepository;
+import com.portfolio.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -36,7 +37,7 @@ public class ContactService {
 
     public ContactDTO updateContact(Long id, ContactDTO dto) {
         Contact contact = contactRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Contacto no encontrado con id: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Contacto no encontrado con id: " + id));
         contact.setName(dto.getName());
         contact.setEmail(dto.getEmail());
         contact.setMessage(dto.getMessage());

--- a/src/main/java/com/portfolio/service/ProjectService.java
+++ b/src/main/java/com/portfolio/service/ProjectService.java
@@ -1,6 +1,7 @@
 package com.portfolio.service;
 
 import com.portfolio.dto.ProjectDTO;
+import com.portfolio.exception.ResourceNotFoundException;
 import com.portfolio.model.Project;
 import com.portfolio.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +37,7 @@ public class ProjectService {
 
     public ProjectDTO updateProject(Long id, ProjectDTO dto) {
         Project project = projectRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Project not found with id: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Project not found with id: " + id));
         project.setTitle(dto.getTitle());
         project.setDescription(dto.getDescription());
         project.setLink(dto.getLink());
@@ -48,19 +49,19 @@ public class ProjectService {
 
     public ProjectDTO getProject(Long id) {
         Project project = projectRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Project not found with id: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Project not found with id: " + id));
         return toDto(project);
     }
 
     public String generateDynamicMessage(Long id) {
         Project project = projectRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Project not found with id: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Project not found with id: " + id));
         return aiService.generateDynamicMessage(project.getStack());
     }
 
     public String generateSummaryMessage(Long id) {
         Project project = projectRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Project not found with id: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Project not found with id: " + id));
         return aiService.generateProjectSummary(project.getTitle(), project.getDescription(), project.getStack());
     }
 

--- a/src/main/java/com/portfolio/service/SkillService.java
+++ b/src/main/java/com/portfolio/service/SkillService.java
@@ -1,6 +1,7 @@
 package com.portfolio.service;
 
 import com.portfolio.dto.SkillDTO;
+import com.portfolio.exception.ResourceNotFoundException;
 import com.portfolio.model.Skill;
 import com.portfolio.repository.SkillRepository;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +35,7 @@ public class SkillService {
 
     public SkillDTO updateSkill(Long id, SkillDTO dto) {
         Skill skill = skillRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Skill no encontrada con id: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Skill no encontrada con id: " + id));
         skill.setName(dto.getName());
         skill.setDescription(dto.getDescription());
         skill = skillRepository.save(skill);


### PR DESCRIPTION
## Summary
- introduce `ErrorResponse` model
- add `ResourceNotFoundException`
- create `GlobalExceptionHandler` with handlers for runtime and validation errors
- use new `ResourceNotFoundException` in services

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_b_6861f9e4e030833399248b888956742e